### PR TITLE
Updates workflows to use the reusable workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,45 @@
+# OS/OSD GitHub Action Guide
+
+## Summary
+
+This document provides the guidance for the useage of GitHub actions.
+
+The current workflows folder contains one deployment workflow(os-osd-deployment.yml) and two reusable workflows(deployment-template.yml and function-tests-template.yml). os-osd-deployment workflow will call deployment-template and function-test-template with required inputs and secrets for the deployment and tests.
+
+- os-osd-deployment.yml
+- deployment-template.yml
+- function-tests-template.yml
+
+## Prerequisites
+
+- GitHub account
+- Public repository
+- GitHub action workflows
+
+
+## Detail workflows
+
+> os-osd-deployment.yml: 
+>> This is a mainly deployment workflow for OpenSearch and OpenSearch Dashboards, it includes dev and prod two environment. 
+
+> deployment-template.yml:
+>> This is a reusable workflow for deployment. It requires couple inputs and secrets. The list of required inputs and secrets.
+>> - inputs: helm-repo, it is offical helm release location of OpenSearch and OpenSearch Dashboards.
+>> - inputs: deploy-env, it is the variable for environment, like as dev or prod.
+>> - secrets: access-key-id, it is access id for EKS cluster.
+>> - secrets: secret-access-key, it is access key for EKS cluster.
+>> - secrets: region, it is cluster region.
+>> - secrets: kube-config, it is client kube configuration which was used to connect to EKS cluster.
+
+> function-tests-template.yml:
+>> This is a reusable function tests workflows for OpeanSearch Dashboards. The required inputs and secrets as following:
+>> - inputs: endpoint, the OpenSearch Dashboard endpoint.
+>> - secrets: osd-user, the write access user of OpenSearch Dashboards.
+>> - secrets: osd-user-password, the write access user's password for OpenSearch Dashboards.
+
+
+## Appendix
+
+- GitHub workflow: https://docs.github.com/en/actions/using-workflows/about-workflows
+
+- Reusable workflow : https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/deployment-template.yml
+++ b/.github/workflows/deployment-template.yml
@@ -1,0 +1,54 @@
+name: OpenSearch and Dashboards Deployment Template
+
+on:
+  workflow_call:
+    inputs:
+      helm-repo:
+        required: true
+        type: string
+      deploy-env:
+        required: true
+        type: string
+    secrets:
+      access-key-id:
+        required: true
+      secret-access-key:
+        required: true
+      region:
+        required: true
+      kube-config:
+        required: true
+
+jobs:
+
+  OS-OSD-Deployment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Step 1 - Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.access-key-id }}
+          aws-secret-access-key: ${{ secrets.secret-access-key }}
+          aws-region: ${{ secrets.region }}
+
+      - name: Step 2 - Deploy OpenSearch and OpenSearch Dashboards By Helm Chart
+        uses: elastic-analytics/dashboards-action@main
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.kube-config }}
+        with:
+          plugins: "" # optional, list of Helm plugins. eg. helm-secrets or helm-diff.
+          # lists couple helm and kubetl commands here as placeholder, will add more
+          # detail deployment command when helm configuration file ready.
+          command: |
+            helm repo add opensearch ${{ inputs.helm-repo }}
+            helm repo update
+            helm search repo opensearch
+            kubectl get nodes
+            helm uninstall opensearch --namespace default
+            helm uninstall dashboards --namespace default
+            kubectl delete pvc --all
+            helm install opensearch opensearch/opensearch -f config/playground/helm/${{inputs.deploy-env}}/helm-opensearch.yaml
+            helm install dashboards opensearch/opensearch-dashboards -f config/playground/helm/${{inputs.deploy-env}}/helm-opensearch-dashboards.yaml

--- a/.github/workflows/deployment-template.yml
+++ b/.github/workflows/deployment-template.yml
@@ -40,8 +40,9 @@ jobs:
           KUBE_CONFIG_DATA: ${{ secrets.kube-config }}
         with:
           plugins: "" # optional, list of Helm plugins. eg. helm-secrets or helm-diff.
-          # lists couple helm and kubetl commands here as placeholder, will add more
-          # detail deployment command when helm configuration file ready.
+          # Teardown the current OS and OSD and then install the lastest version
+          # of OS and OSD as it only takes 23 seconds for the process, will add
+          # blue/green deployment later.
           command: |
             helm repo add opensearch ${{ inputs.helm-repo }}
             helm repo update

--- a/.github/workflows/function-tests-template.yml
+++ b/.github/workflows/function-tests-template.yml
@@ -1,0 +1,162 @@
+name: OpenSearch Dashboards Function Tests Template
+
+on:
+  workflow_call:
+    inputs:
+      endpoint:
+        required: true
+        type: string
+    secrets:
+      osd-user:
+        required: true
+      osd-user-password:
+        required: true
+
+env:
+  # TODO: merge all the changes to OpenSearch-Project's function repo.
+  function-repo: elastic-analytics/opensearch-dashboards-functional-test
+  function-branch: playground
+
+jobs:
+
+  # Run OpenSearch Dashboard tests first and then
+  # run all the plugin tests in parallel.
+  OSD-Functional-Test-OSD:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout function test repo
+          uses: actions/checkout@v3
+          with:
+            repository: $function-repo
+            ref: $function-branch
+
+        - name: Step 0 - Install dependencies for function test
+          run: |
+            npm install
+            npm install -g yarn
+
+        - name: Step 1 - Check If OSD is Up
+          run: |
+            sleep 30s
+            curl -XGET -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
+            echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
+
+        - name: Step 2 - Run Function Test For OSD
+          if: ${{ env.OSD_STATUS == 'green'}}
+          run: |
+            yarn cypress run --spec "cypress/integration/playground/dashboards/*.js" --config "baseUrl=${{inputs.endpoint}}" --env "openSearchUrl=${{inputs.endpoint}},SECURITY_ENABLED=true,username=${{secrets.osd-user}},password=${{secrets.osd-user-password}}"
+
+  OSD-Functional-Test-AD:
+      needs: [OSD-Functional-Test-OSD]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout function test repo
+          uses: actions/checkout@v3
+          with:
+            repository: $function-repo
+            ref: $function-branch
+
+        - name: Step 0 - Install dependencies for function test
+          run: |
+            npm install
+            npm install -g yarn
+
+        - name: Step 1 - Run Function Test For AD
+          run: |
+            yarn cypress run --spec "cypress/integration/playground/plugins/playground_ad*.js" --config "baseUrl=${{inputs.endpoint}}" --env "openSearchUrl=${{inputs.endpoint}},SECURITY_ENABLED=true,username=${{secrets.osd-user}},password=${{secrets.osd-user-password}}"
+
+  OSD-Functional-Test-Alert:
+      needs: [OSD-Functional-Test-OSD]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout function test repo
+          uses: actions/checkout@v3
+          with:
+            repository: $function-repo
+            ref: $function-branch
+
+        - name: Step 0 - Install dependencies for function test
+          run: |
+            npm install
+            npm install -g yarn
+
+        - name: Step 1 - Run Function Test For Alert
+          run: |
+            yarn cypress run --spec "cypress/integration/playground/plugins/playground_alert*.js" --config "baseUrl=${{inputs.endpoint}}" --env "openSearchUrl=${{inputs.endpoint}},SECURITY_ENABLED=true,username=${{secrets.osd-user}},password=${{secrets.osd-user-password}}"
+
+  OSD-Functional-Test-Notifications:
+      needs: [OSD-Functional-Test-OSD]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout function test repo
+          uses: actions/checkout@v3
+          with:
+            repository: $function-repo
+            ref: $function-branch
+
+        - name: Step 0 - Install dependencies for function test
+          run: |
+            npm install
+            npm install -g yarn
+
+        - name: Step 1 - Run Function Test For Alert
+          run: |
+            yarn cypress run --spec "cypress/integration/playground/plugins/playground_notifications*.js" --config "baseUrl=${{inputs.endpoint}}" --env "openSearchUrl=${{inputs.endpoint}},SECURITY_ENABLED=true,username=${{secrets.osd-user}},password=${{secrets.osd-user-password}}"
+
+  OSD-Functional-Test-Reports:
+      needs: [OSD-Functional-Test-OSD]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout function test repo
+          uses: actions/checkout@v3
+          with:
+            repository: $function-repo
+            ref: $function-branch
+
+        - name: Step 0 - Install dependencies for function test
+          run: |
+            npm install
+            npm install -g yarn
+
+        - name: Step 1 - Run Function Test For Reports
+          run: |
+            yarn cypress run --spec "cypress/integration/playground/plugins/playground_reports*.js" --config "baseUrl=${{inputs.endpoint}}" --env "openSearchUrl=${{inputs.endpoint}},SECURITY_ENABLED=true,username=${{secrets.osd-user}},password=${{secrets.osd-user-password}}"
+
+  OSD-Functional-Test-Observability:
+      needs: [OSD-Functional-Test-OSD]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout function test repo
+          uses: actions/checkout@v3
+          with:
+            repository: $function-repo
+            ref: $function-branch
+
+        - name: Step 0 - Install dependencies for function test
+          run: |
+            npm install
+            npm install -g yarn
+
+        - name: Step 1 - Run Function Test For Observability
+          run: |
+            yarn cypress run --spec "cypress/integration/playground/plugins/playground_observability*.js" --config "baseUrl=${{inputs.endpoint}}" --env "openSearchUrl=${{inputs.endpoint}},SECURITY_ENABLED=true,username=${{secrets.osd-user}},password=${{secrets.osd-user-password}}"
+
+
+  OSD-Functional-Test-IndexMan:
+      needs: [OSD-Functional-Test-OSD]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout function test repo
+          uses: actions/checkout@v3
+          with:
+            repository: $function-repo
+            ref: $function-branch
+
+        - name: Step 0 - Install dependencies for function test
+          run: |
+            npm install
+            npm install -g yarn
+
+        - name: Step 1 - Run Function Test For Index Management
+          run: |
+            yarn cypress run --spec "cypress/integration/playground/plugins/playground_index*.js" --config "baseUrl=${{inputs.endpoint}}" --env "openSearchUrl=${{inputs.endpoint}},SECURITY_ENABLED=true,username=${{secrets.osd-user}},password=${{secrets.osd-user-password}}"

--- a/.github/workflows/function-tests-template.yml
+++ b/.github/workflows/function-tests-template.yml
@@ -14,6 +14,8 @@ on:
 
 env:
   # TODO: merge all the changes to OpenSearch-Project's function repo.
+  # Issue for tracking this todo work.
+  # https://github.com/opensearch-project/dashboards-anywhere/issues/46
   function-repo: elastic-analytics/opensearch-dashboards-functional-test
   function-branch: playground
 

--- a/.github/workflows/os-osd-deployment.yml
+++ b/.github/workflows/os-osd-deployment.yml
@@ -35,7 +35,7 @@ jobs:
   OS-OSD-Dev-Deployment:
     needs: Pre-Deployment
     if:  ${{ needs.Pre-Deployment.outputs.config_change_dev == 'true' }}
-    uses:  opensearch-project/dashboards-anywhere/.github/workflows/reusable-deployment.yml@featureaction
+    uses:  opensearch-project/dashboards-anywhere/.github/workflows/deployment-template.yml@featureaction
     with:
       helm-repo: $helm-repo
       deploy-env: dev
@@ -48,7 +48,7 @@ jobs:
   OS-OSD-Prod-Deployment:
     needs: Pre-Deployment
     if: ${{ needs.Pre-Deployment.outputs.config_change_prod == 'true'}}
-    uses:  opensearch-project/dashboards-anywhere/.github/workflows/reusable-deployment.yml@featureaction
+    uses:  opensearch-project/dashboards-anywhere/.github/workflows/deployment-template.yml@featureaction
     with:
       helm-repo: $helm-repo
       deploy-env: prod
@@ -60,7 +60,7 @@ jobs:
 
   OSD-Functional-Test-Dev:
         needs: OS-OSD-Dev-Deployment
-        uses: opensearch-project/dashboards-anywhere/.github/workflows/reusable-function-test.yml@featureaction
+        uses: opensearch-project/dashboards-anywhere/.github/workflows/function-tests-template.yml@featureaction
         with:
           endpoint: https://playground.opensearch.oss.aws.dev
         secrets:
@@ -69,7 +69,7 @@ jobs:
 
   OSD-Functional-Test-Prod:
         needs: OS-OSD-Prod-Deployment
-        uses: opensearch-project/dashboards-anywhere/.github/workflows/reusable-function-test.yml@featureaction
+        uses: opensearch-project/dashboards-anywhere/.github/workflows/function-tests-template.yml@featureaction
         with:
           endpoint: https://playground.opensearch.org
         secrets:

--- a/.github/workflows/os-osd-deployment.yml
+++ b/.github/workflows/os-osd-deployment.yml
@@ -1,4 +1,5 @@
-# This workflow was used for deploying the latest version of OpenSearch and OpenSearch Dashboards to AWS EKS (Elastic Kubernetes Service) cluster.
+# This workflow was used for deploying the latest version of OpenSearch
+# and OpenSearch Dashboards to AWS EKS (Elastic Kubernetes Service) cluster.
 name: Deploy OpenSearch and OpenSearch Dashboards 
 
 on:
@@ -6,6 +7,9 @@ on:
     branches: [ main ]
   # adds workflow_dispatch for manually running a workflow
   workflow_dispatch:
+
+env:
+  helm-repo: https://opensearch-project.github.io/helm-charts/
 
 jobs:
 
@@ -29,103 +33,45 @@ jobs:
               - 'config/playground/helm/prod/**'
 
   OS-OSD-Dev-Deployment:
-    if: ${{ needs.Pre-Deployment.outputs.config_change_dev == 'true'}}
-    runs-on: ubuntu-latest
-
     needs: Pre-Deployment
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Step 1 - Dev - Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
-          aws-region: ${{ secrets.AWS_REGION_DEV }}
-
-      - name: Step 2 - Dev - Deploy OpenSearch and OpenSearch Dashboards By Helm Chart
-        uses: elastic-analytics/dashboards-action@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA_DEV }}
-        with:
-          plugins: "" # optional, list of Helm plugins. eg. helm-secrets or helm-diff.
-          # lists couple helm and kubetl commands here as placeholder, will add more
-          # detail deployment command when helm configuration file ready.
-          command: |
-            helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-            helm repo update
-            helm search repo opensearch
-            kubectl get nodes
+    if:  ${{ needs.Pre-Deployment.outputs.config_change_dev == 'true' }}
+    uses:  opensearch-project/dashboards-anywhere/.github/workflows/reusable-deployment.yml@featureaction
+    with:
+      helm-repo: $helm-repo
+      deploy-env: dev
+    secrets:
+      access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
+      secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
+      region: ${{ secrets.AWS_REGION_DEV }}
+      kube-config: ${{ secrets.KUBE_CONFIG_DATA_DEV }}
 
   OS-OSD-Prod-Deployment:
+    needs: Pre-Deployment
     if: ${{ needs.Pre-Deployment.outputs.config_change_prod == 'true'}}
-    runs-on: ubuntu-latest
+    uses:  opensearch-project/dashboards-anywhere/.github/workflows/reusable-deployment.yml@featureaction
+    with:
+      helm-repo: $helm-repo
+      deploy-env: prod
+    secrets:
+      access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
+      secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+      region: ${{ secrets.AWS_REGION_PROD }}
+      kube-config: ${{ secrets.KUBE_CONFIG_DATA_PROD }}
 
-    needs: Pre-Deployment
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Step 1 - Prod - Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+  OSD-Functional-Test-Dev:
+        needs: OS-OSD-Dev-Deployment
+        uses: opensearch-project/dashboards-anywhere/.github/workflows/reusable-function-test.yml@featureaction
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
-          aws-region: ${{ secrets.AWS_REGION_PROD }}
+          endpoint: https://playground.opensearch.oss.aws.dev
+        secrets:
+          osd-user: ${{ secrets.OSD_USER }}
+          osd-user-password: ${{ secrets.OSD_USER_PASSWORD }}
 
-      - name: Step 2 - Prod - Deploy OpenSearch and OpenSearch Dashboards By Helm Chart
-        uses: elastic-analytics/dashboards-action@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA_PROD }}
+  OSD-Functional-Test-Prod:
+        needs: OS-OSD-Prod-Deployment
+        uses: opensearch-project/dashboards-anywhere/.github/workflows/reusable-function-test.yml@featureaction
         with:
-          plugins: "" # optional, list of Helm plugins. eg. helm-secrets or helm-diff.
-          command: |
-            helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-            helm repo update
-            helm search repo opensearch
-            kubectl get nodes
-
-  OS-OSD-All-Deployment:
-    if: ${{ needs.Pre-Deployment.outputs.config_change_dev == 'true' && needs.Pre-Deployment.outputs.config_change_prod == 'true'}}
-    runs-on: ubuntu-latest
-
-    needs: Pre-Deployment
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Step 1 - Dev - Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
-          aws-region: ${{ secrets.AWS_REGION_DEV }}
-
-      - name: Step 2 - Dev - Deploy OpenSearch and OpenSearch Dashboards By Helm Chart
-        uses: elastic-analytics/dashboards-action@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA_DEV }}
-        with:
-          plugins: "" # optional, list of Helm plugins. eg. helm-secrets or helm-diff.
-          command: |
-            helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-            helm repo update
-            helm search repo opensearch
-            kubectl get nodes
-
-      - name: Step 3 - Prod - Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
-          aws-region: ${{ secrets.AWS_REGION_PROD }}
-
-      - name: Step 4 - Prod - Deploy OpenSearch and OpenSearch Dashboards By Helm Chart
-        uses: elastic-analytics/dashboards-action@main
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA_PROD }}
-        with:
-          plugins: "" # optional, list of Helm plugins. eg. helm-secrets or helm-diff.
-          command: |
-            helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-            helm repo update
-            helm search repo opensearch
-            kubectl get nodes
+          endpoint: https://playground.opensearch.org
+        secrets:
+          osd-user: ${{ secrets.OSD_USER }}
+          osd-user-password: ${{ secrets.OSD_USER_PASSWORD }}


### PR DESCRIPTION
Signed-off-by: Tao liu <liutaoaz@amazon.com>

### Description
Creates two reusable workflow for the deployment, and adds function tests to post deployment.
- Deployment template
- Function test template

Sample pipeline run as following:

<img width="915" alt="image" src="https://user-images.githubusercontent.com/33105471/177925701-33aff4b6-6dd5-440b-8510-7d261be40fdc.png">


Note, reusable workflow can't call others [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations) 
 
### Issues Resolved
Resolve #38 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
