### PR TITLE
[OpenSearch Playground] Fixes the helm-repo connection issue when env context is not available to job.if

### DIFF
--- a/.github/workflows/os-osd-deployment.yml
+++ b/.github/workflows/os-osd-deployment.yml
@@ -8,9 +8,6 @@ on:
   # adds workflow_dispatch for manually running a workflow
   workflow_dispatch:
 
-env:
-  helm-repo: https://opensearch-project.github.io/helm-charts/
-
 jobs:
 
   Pre-Deployment:
@@ -37,7 +34,7 @@ jobs:
     if:  ${{ needs.Pre-Deployment.outputs.config_change_dev == 'true' }}
     uses:  opensearch-project/dashboards-anywhere/.github/workflows/deployment-template.yml@main
     with:
-      helm-repo: ${{ env.helm-repo }}
+      helm-repo: https://opensearch-project.github.io/helm-charts/
       deploy-env: dev
     secrets:
       access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
@@ -50,7 +47,7 @@ jobs:
     if: ${{ needs.Pre-Deployment.outputs.config_change_prod == 'true'}}
     uses:  opensearch-project/dashboards-anywhere/.github/workflows/deployment-template.yml@main
     with:
-      helm-repo: ${{ env.helm-repo }}
+      helm-repo: https://opensearch-project.github.io/helm-charts/
       deploy-env: prod
     secrets:
       access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}


### PR DESCRIPTION
Signed-off-by: Tao liu <liutaoaz@amazon.com>

### Description
The environment variable helm-repo was not correctly passed to OS and OSD deployment.
Note, env context is not available to job.if. the reference here https://github.com/actions/runner/issues/1189
 
### Issues Resolved
Resolve #55 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
