### PR TITLE
[OpenSearch Playground] Ignore DS_Store and update action checkout

### DIFF
--- a/.github/workflows/deployment-template.yml
+++ b/.github/workflows/deployment-template.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Step 1 - Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/os-osd-deployment.yml
+++ b/.github/workflows/os-osd-deployment.yml
@@ -18,7 +18,7 @@ jobs:
       config_change_prod: ${{steps.filter.outputs.prod}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store


### PR DESCRIPTION
Signed-off-by: Tao Liu <liutaoaz@amazon.com>

### Description
According to currently github's Annotations, we need to upgrade node12 to node16 which checkout VS already use it.
 
### Issues Resolved
````
Pre-Deployment
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout

````
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
