### PR TITLE
This is to add release note automation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -19,6 +19,7 @@ changelog:
     - title: Security fix
       labels:
         - cve
+        - security vulnerability
     - title: Bug Fix
     - title: Other Changes
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - amazon-auto
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+        - feature
+    - title: Security fix
+      labels:
+        - cve
+    - title: Bug Fix
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
### Description
This is to add release automation to anywhere project, so we could generate release note automatically 

refer to example release note generated
https://github.com/seraphjiang/dashboards-anywhere/releases/tag/v0.9.1

![image](https://user-images.githubusercontent.com/550437/197367869-eb51442d-232b-4daf-b29c-1dee93d187f9.png)

 
### Issues Resolved
resolve https://github.com/opensearch-project/dashboards-anywhere/issues/89
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
