### PR TITLE
remove default field

### DIFF
--- a/.github/workflows/deployment-template.yml
+++ b/.github/workflows/deployment-template.yml
@@ -20,7 +20,6 @@ on:
         required: true
       ga-tracking-id:
         required: false
-        default: ''
 
 jobs:
 


### PR DESCRIPTION
Signed-off-by: Lu Yu <nluyu@amazon.com>

### Description
This is a fix to current workflow to remove default field since it is not supported for secrets input
 
### Issues Resolved
NA
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
