### PR TITLE
Enable security analytics plugin functional test and add retry when checking if OSD is up 

### DIFF
--- a/.github/workflows/functional-test-template.yml
+++ b/.github/workflows/functional-test-template.yml
@@ -28,10 +28,14 @@ jobs:
             npm install -g yarn
 
         - name: Step 1 - Check If OSD is Up
-          run: |
-            sleep 30s
-            curl -XGET -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
-            echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
+          uses: ./
+          with:
+            timeout_minutes: 10
+            max_attempts: 3
+            command: |
+              sleep 30s
+              curl -XGET -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
+              echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
 
         - name: Step 2 - Run Functional Test For OSD
           if: ${{ env.OSD_STATUS == 'green'}}
@@ -43,8 +47,8 @@ jobs:
     needs: OSD-Functional-Test-OSD
     strategy:
       fail-fast: false
-      matrix: 
-        run: ['OSD-Functional-Test-AD', 'OSD-Functional-Test-Alert', 'OSD-Functional-Test-Notifications', 'OSD-Functional-Test-Reports', 'OSD-Functional-Test-Observability', 'OSD-Functional-Test-IndexMan']
+      matrix:
+        run: ['OSD-Functional-Test-AD', 'OSD-Functional-Test-Alert', 'OSD-Functional-Test-Notifications', 'OSD-Functional-Test-Reports', 'OSD-Functional-Test-Observability', 'OSD-Functional-Test-IndexMan', 'OSD-Functional-Test-SecurityAnalytics']
     steps:
     - run: echo Run ${{ matrix.run }}
     - name: Checkout functional test repo
@@ -85,3 +89,8 @@ jobs:
       if:  ${{ matrix.run == 'OSD-Functional-Test-IndexMan' }}
       run: |
         yarn cypress run --spec "cypress/integration/playground/plugins/playground_index*.js" --config "baseUrl=${{inputs.endpoint}}" --env "openSearchUrl=${{inputs.endpoint}},SECURITY_ENABLED=true,username=${{secrets.osd-user}},password=${{secrets.osd-user-password}}"
+
+    - name: Run Functional Test For Security Analytics
+      if: ${{ matrix.run == 'OSD-Functional-Test-SecurityAnalytics' }}
+      run: |
+        yarn cypress run --spec "cypress/integration/playground/plugins/playground_security_analytics*.js" --config "baseUrl=${{inputs.endpoint}}" --env "openSearchUrl=${{inputs.endpoint}},SECURITY_ENABLED=true,username=${{secrets.osd-user}},password=${{secrets.osd-user-password}}"

--- a/.github/workflows/functional-test-template.yml
+++ b/.github/workflows/functional-test-template.yml
@@ -28,10 +28,14 @@ jobs:
             npm install -g yarn
 
         - name: Step 1 - Check If OSD is Up
-          run: |
-            sleep 30s
-            curl -XGET --retry 10 --retry-delay 30 -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
-            echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
+          uses: nick-fields/retry@v2
+          with:
+            timeout_minutes: 10
+            max_attempts: 3
+            command: |
+              sleep 30s
+              curl -XGET -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
+              echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
 
         - name: Step 2 - Run Functional Test For OSD
           if: ${{ env.OSD_STATUS == 'green'}}

--- a/.github/workflows/functional-test-template.yml
+++ b/.github/workflows/functional-test-template.yml
@@ -28,14 +28,10 @@ jobs:
             npm install -g yarn
 
         - name: Step 1 - Check If OSD is Up
-          uses: nick-fields/retry@v2
-          with:
-            timeout_minutes: 10
-            max_attempts: 3
-            command: |
-              sleep 30s
-              curl -XGET -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
-              echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
+          run: |
+            sleep 30s
+            curl -XGET -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
+            echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
 
         - name: Step 2 - Run Functional Test For OSD
           if: ${{ env.OSD_STATUS == 'green'}}

--- a/.github/workflows/functional-test-template.yml
+++ b/.github/workflows/functional-test-template.yml
@@ -29,13 +29,10 @@ jobs:
 
         - name: Step 1 - Check If OSD is Up
           uses: ./
-          with:
-            timeout_minutes: 10
-            max_attempts: 3
-            command: |
-              sleep 30s
-              curl -XGET -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
-              echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
+          run: |
+            sleep 30s
+            curl -XGET --retry 10 --retry-delay 30 -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
+            echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
 
         - name: Step 2 - Run Functional Test For OSD
           if: ${{ env.OSD_STATUS == 'green'}}

--- a/.github/workflows/functional-test-template.yml
+++ b/.github/workflows/functional-test-template.yml
@@ -28,7 +28,6 @@ jobs:
             npm install -g yarn
 
         - name: Step 1 - Check If OSD is Up
-          uses: ./
           run: |
             sleep 30s
             curl -XGET --retry 10 --retry-delay 30 -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json

--- a/.github/workflows/os-osd-deployment.yml
+++ b/.github/workflows/os-osd-deployment.yml
@@ -60,7 +60,7 @@ jobs:
 
   OSD-Functional-Test-Dev:
         needs: OS-OSD-Dev-Deployment
-        uses: opensearch-project/dashboards-anywhere/.github/workflows/functional-test-template.yml@main
+        uses: opensearch-project/dashboards-anywhere/.github/workflows/functional-test-template.yml@addft
         with:
           endpoint: https://playground.opensearch.oss.aws.dev
         secrets:

--- a/.github/workflows/os-osd-deployment.yml
+++ b/.github/workflows/os-osd-deployment.yml
@@ -60,7 +60,7 @@ jobs:
 
   OSD-Functional-Test-Dev:
         needs: OS-OSD-Dev-Deployment
-        uses: opensearch-project/dashboards-anywhere/.github/workflows/functional-test-template.yml@addft
+        uses: opensearch-project/dashboards-anywhere/.github/workflows/functional-test-template.yml@main
         with:
           endpoint: https://playground.opensearch.oss.aws.dev
         secrets:

--- a/config/playground/helm/dev/helm-opensearch-dashboards.yaml
+++ b/config/playground/helm/dev/helm-opensearch-dashboards.yaml
@@ -151,7 +151,7 @@ affinity: {}
 # -- Array of extra K8s manifests to deploy
 extraObjects: []
 
-# specify the plugins to install
+# specify the external plugins to install
 plugins:
   enabled: true
   installList: ["https://github.com/BionIT/google-analytics-plugin/releases/download/2.4.1/googleAnalytics-2.4.1.zip"]

--- a/config/playground/helm/dev/helm-opensearch-dashboards.yaml
+++ b/config/playground/helm/dev/helm-opensearch-dashboards.yaml
@@ -151,7 +151,7 @@ affinity: {}
 # -- Array of extra K8s manifests to deploy
 extraObjects: []
 
-# specify the plugin to install
+# specify the plugins to install
 plugins:
   enabled: true
   installList: ["https://github.com/BionIT/google-analytics-plugin/releases/download/2.4.1/googleAnalytics-2.4.1.zip"]


### PR DESCRIPTION
### Description
Enable security analytics plugin functional test and add retry when checking if OSD is up 
 
### Issues Resolved
Resolves #131 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
