### PR TITLE
add retry when checking if OSD is up with 30s delay

### DIFF
--- a/.github/workflows/functional-test-template.yml
+++ b/.github/workflows/functional-test-template.yml
@@ -30,7 +30,7 @@ jobs:
         - name: Step 1 - Check If OSD is Up
           run: |
             sleep 30s
-            curl -XGET -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
+            curl -XGET --retry 15 --retry-delay 30 --retry-all-errors -k -u '${{secrets.osd-user}}:${{secrets.osd-user-password}}' '${{inputs.endpoint}}/api/status' > $HOME/osd-response.json
             echo "OSD_STATUS=$(cat $HOME/osd-response.json | jq -r '.status.overall.state')" >> $GITHUB_ENV
 
         - name: Step 2 - Run Functional Test For OSD


### PR DESCRIPTION
Signed-off-by: Lu Yu <nluyu@amazon.com>

### Description
Add retries when we check OSD status before doing FT
 
### Issues Resolved
Resolves #133  

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
