### PR TITLE
Change ml-commons node instance setting to make it optimal for data loading and searching

### DIFF
--- a/config/playground/helm/ml/helm-machinelearning.yaml
+++ b/config/playground/helm/ml/helm-machinelearning.yaml
@@ -107,8 +107,8 @@ opensearchJavaOpts: "-Xmx2G -Xms2G"
 
 resources:
   requests:
-    cpu: "2"
-    memory: "16Gi"
+    cpu: "16"
+    memory: "128Gi"
 
 networkHost: "0.0.0.0"
 

--- a/config/playground/helm/ml/helm-machinelearning.yaml
+++ b/config/playground/helm/ml/helm-machinelearning.yaml
@@ -103,12 +103,12 @@ podAnnotations: {}
 # additionals labels
 labels: {}
 
-opensearchJavaOpts: "-Xmx2G -Xms2G"
+opensearchJavaOpts: "-Xmx48G -Xms48G"
 
 resources:
   requests:
     cpu: "16"
-    memory: "128Gi"
+    memory: "96Gi"
 
 networkHost: "0.0.0.0"
 

--- a/config/playground/helm/ml/helm-machinelearning.yaml
+++ b/config/playground/helm/ml/helm-machinelearning.yaml
@@ -11,8 +11,8 @@ masterService: "opensearch-cluster-leader"
 roles:
   - ml
 
-replicas: 2
-minimumMasterNodes: 2
+replicas: 1
+minimumMasterNodes: 1
 
 # if not set, falls back to parsing .Values.imageTag, then .Chart.appVersion.
 majorVersion: "7"
@@ -103,12 +103,12 @@ podAnnotations: {}
 # additionals labels
 labels: {}
 
-opensearchJavaOpts: "-Xmx48G -Xms48G"
+opensearchJavaOpts: "-Xmx50G -Xms50G"
 
 resources:
   requests:
     cpu: "16"
-    memory: "96Gi"
+    memory: "100Gi"
 
 networkHost: "0.0.0.0"
 

--- a/config/playground/helm/ml/helm-opensearch.yaml
+++ b/config/playground/helm/ml/helm-opensearch.yaml
@@ -106,12 +106,12 @@ podAnnotations: {}
 # additionals labels
 labels: {}
 
-opensearchJavaOpts: "-Xmx2G -Xms2G"
+opensearchJavaOpts: "-Xmx36G -Xms36G"
 
 resources:
   requests:
-    cpu: "16"
-    memory: "128Gi"
+    cpu: "4"
+    memory: "72Gi"
 
 networkHost: "0.0.0.0"
 

--- a/config/playground/helm/ml/helm-opensearch.yaml
+++ b/config/playground/helm/ml/helm-opensearch.yaml
@@ -106,12 +106,12 @@ podAnnotations: {}
 # additionals labels
 labels: {}
 
-opensearchJavaOpts: "-Xmx36G -Xms36G"
+opensearchJavaOpts: "-Xmx50G -Xms50G"
 
 resources:
   requests:
-    cpu: "8"
-    memory: "72Gi"
+    cpu: "16"
+    memory: "100Gi"
 
 networkHost: "0.0.0.0"
 

--- a/config/playground/helm/ml/helm-opensearch.yaml
+++ b/config/playground/helm/ml/helm-opensearch.yaml
@@ -110,8 +110,8 @@ opensearchJavaOpts: "-Xmx2G -Xms2G"
 
 resources:
   requests:
-    cpu: "2"
-    memory: "16Gi"
+    cpu: "16"
+    memory: "128Gi"
 
 networkHost: "0.0.0.0"
 

--- a/config/playground/helm/ml/helm-opensearch.yaml
+++ b/config/playground/helm/ml/helm-opensearch.yaml
@@ -110,7 +110,7 @@ opensearchJavaOpts: "-Xmx36G -Xms36G"
 
 resources:
   requests:
-    cpu: "4"
+    cpu: "8"
     memory: "72Gi"
 
 networkHost: "0.0.0.0"


### PR DESCRIPTION
### Description
Change both ml nodes configuration and data node configuration. Scale them up from 2cpu 16GB memory to 16cpu 128GB memory. KNN group believe this configuration is required for ml-playground.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
