### PR TITLE
Change the role permission and add secret to register S3 and allowing the snapshot for ml-playground

### DIFF
--- a/config/playground/helm/ml/helm-machinelearning.yaml
+++ b/config/playground/helm/ml/helm-machinelearning.yaml
@@ -684,8 +684,10 @@ securityConfig:
             - cluster:admin/opendistro/ism/managedindex/explain
             - cluster:admin/opendistro/rollup/search
             - cluster:admin/opendistro/transform/get_transforms
-            # To enable read access ml profile
+            # To enable train, predict and read access ml profile
             - cluster:admin/opensearch/ml/profile/nodes
+            - cluster:admin/opensearch/ml/train
+            - cluster:admin/opensearch/ml/predict
             # To enable read access to various ISM Jobs
             - cluster:admin/opendistro/rollup/explain
             - cluster:admin/opendistro/ism/policy/get
@@ -990,7 +992,9 @@ masterTerminationFix: false
 
 lifecycle: {}
 
-keystore: []
+keystore:
+  - secretName: os-snapshot-access
+  - secretName: os-snapshot-secret
 
 networkPolicy:
   ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
@@ -1011,5 +1015,5 @@ sysctl:
 
 ## Enable to add 3rd Party / Custom plugins not offered in the default OpenSearch image.
 plugins:
-  enabled: false
-  installList: []
+  enabled: true
+  installList: [repository-s3]

--- a/config/playground/helm/ml/helm-opensearch.yaml
+++ b/config/playground/helm/ml/helm-opensearch.yaml
@@ -687,8 +687,10 @@ securityConfig:
             - cluster:admin/opendistro/ism/managedindex/explain
             - cluster:admin/opendistro/rollup/search
             - cluster:admin/opendistro/transform/get_transforms
-            # To enable read access ml profile
+            # To enable train, predict and read access ml profile
             - cluster:admin/opensearch/ml/profile/nodes
+            - cluster:admin/opensearch/ml/train
+            - cluster:admin/opensearch/ml/predict
             # To enable read access to various ISM Jobs
             - cluster:admin/opendistro/rollup/explain
             - cluster:admin/opendistro/ism/policy/get
@@ -995,6 +997,8 @@ lifecycle: {}
 
 keystore:
   - secretName: opensearch-dashboards-ob
+  - secretName: os-snapshot-access
+  - secretName: os-snapshot-secret
 
 networkPolicy:
   ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
@@ -1015,5 +1019,5 @@ sysctl:
 
 ## Enable to add 3rd Party / Custom plugins not offered in the default OpenSearch image.
 plugins:
-  enabled: false
-  installList: []
+  enabled: true
+  installList: [repository-s3]


### PR DESCRIPTION
### Description
This should allow anonymous user role to train and predict model. Meanwhile enabling the registry to s3 bucket so that we can store snapshots and restore indices from these snapshots.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
