### PR TITLE
Change searchApps playground to track 2.8.0

### DIFF
--- a/config/playground/helm/searchapps/helm-opensearch-dashboards.yaml
+++ b/config/playground/helm/searchapps/helm-opensearch-dashboards.yaml
@@ -11,7 +11,7 @@ replicaCount: 3
 image:
   repository: "opensearchstaging/opensearch-dashboards"
   # override image tag, which is .Chart.AppVersion by default
-  tag: "3.0.0"
+  tag: "2.8.0"
   pullPolicy: "Always"
 
 imagePullSecrets: []

--- a/config/playground/helm/searchapps/helm-opensearch.yaml
+++ b/config/playground/helm/searchapps/helm-opensearch.yaml
@@ -32,6 +32,8 @@ config:
     cluster.name: opensearch-cluster
     # Bind to all interfaces because we don't know what IP address Docker will assign to us.
     network.host: 0.0.0.0
+    # Enable search pipeline
+    opensearch.experimental.feature.search_pipeline.enabled: true
     # # minimum_master_nodes need to be explicitly set when bound on a public IP
     # # set to 1 to allow single node clusters
     # discovery.zen.minimum_master_nodes: 1
@@ -98,7 +100,7 @@ hostAliases: []
 image:
   repository: "opensearchstaging/opensearch"
   # override image tag, which is .Chart.AppVersion by default
-  tag: "3.0.0"
+  tag: "2.8.0"
   pullPolicy: "Always"
 
 podAnnotations: {}


### PR DESCRIPTION
### Description
Change searchApps playground to track 2.8.0

Latest 2.8.0 build https://build.ci.opensearch.org/job/distribution-build-opensearch/7879/
Docker image: https://hub.docker.com/layers/opensearchstaging/opensearch-dashboards/2.8.0/images/sha256-213567cf98ca1772e3577e5aca79cd2e8225c9593f5bdbf058f84cb1992e021c?context=explore
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
